### PR TITLE
Config useTimestamps

### DIFF
--- a/examples/Assets.php
+++ b/examples/Assets.php
@@ -28,6 +28,9 @@ class Assets extends \Tatter\Assets\Config\Assets
 	// Starting directory for manifest publication
 	public $publishBase = ROOTPATH . 'vendor/';
 	
+	// Whether to append file modification timestamps on asset tags
+	public $useTimestamps = true;
+	
 	// Additional paths to load per route
 	// Relative to fileBase, no leading/trailing slashes
 	public $routes = [

--- a/src/Config/Assets.php
+++ b/src/Config/Assets.php
@@ -19,6 +19,9 @@ class Assets extends BaseConfig
 	// Starting directory for manifest publication
 	public $publishBase = ROOTPATH . 'vendor/';
 	
+	// Whether to append file modification timestamps on asset tags
+	public $useTimestamps = true;
+	
 	// Additional paths to load per route
 	// Relative to fileBase, no leading/trailing slashes
 	public $routes = [];

--- a/src/Libraries/Assets.php
+++ b/src/Libraries/Assets.php
@@ -186,7 +186,7 @@ class Assets
 		
 		// Check for the actual file for version control
 		$file = $this->config->fileBase . $path;
-		if (is_file($file))
+		if (is_file($file) && $this->config->useTimestamps)
 		{
 			$url .=  '?v=' . filemtime($file);
 		}

--- a/tests/assets/LibraryTest.php
+++ b/tests/assets/LibraryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use CodeIgniter\Config\Services;
+use Tatter\Assets\Libraries\Assets;
+use Tests\Support\AssetsTestCase;
+
+class LibraryTest extends AssetsTestCase
+{
+	public function testTagAddsTimestamps()
+	{
+		$file   = 'alert.js';
+		$result = $this->assets->tag($file);
+
+		$this->assertEquals('<script src="http://example.com/assets/alert.js?v=1594481279" type="text/javascript"></script>', $result);
+	}
+
+	public function testTagRespectsConfigUseTimestamps()
+	{
+		$this->config->useTimestamps = false;
+
+		$file   = 'alert.js';
+		$assets = new Assets($this->config);
+		$result = $assets->tag($file);
+
+		$this->assertEquals('<script src="http://example.com/assets/alert.js" type="text/javascript"></script>', $result);
+	}
+}

--- a/tests/assets/LibraryTest.php
+++ b/tests/assets/LibraryTest.php
@@ -10,8 +10,9 @@ class LibraryTest extends AssetsTestCase
 	{
 		$file   = 'alert.js';
 		$result = $this->assets->tag($file);
+		$suffix = '?v=' . filemtime($this->config->fileBase . $file);
 
-		$this->assertEquals('<script src="http://example.com/assets/alert.js?v=1594481279" type="text/javascript"></script>', $result);
+		$this->assertEquals('<script src="http://example.com/assets/alert.js' . $suffix . '" type="text/javascript"></script>', $result);
 	}
 
 	public function testTagRespectsConfigUseTimestamps()


### PR DESCRIPTION
Adds a configuration option `$useTimestamps`  to control whether the file modification suffix is appended to asset tags, e.g.  `?v=1594481279`.