### PR TITLE
Bundle Caching

### DIFF
--- a/src/Bundle.php
+++ b/src/Bundle.php
@@ -176,4 +176,30 @@ abstract class Bundle
 
         return implode(PHP_EOL, $lines);
     }
+
+    //--------------------------------------------------------------------
+    // Caching
+    //--------------------------------------------------------------------
+
+    /**
+     * Prepares the bundle for caching.
+     *
+     * @return Asset[]
+     */
+    public function __serialize(): array
+    {
+        return $this->getAssets();
+    }
+
+    /**
+     * Restores the bundle from cached version.
+     *
+     * @param Asset[] $data
+     */
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $asset) {
+            $this->add($asset);
+        }
+    }
 }

--- a/src/RouteBundle.php
+++ b/src/RouteBundle.php
@@ -62,26 +62,4 @@ final class RouteBundle extends Bundle
 
         return $bundle;
     }
-
-    /**
-     * Prepares the bundle for caching.
-     *
-     * @return Asset[]
-     */
-    public function __serialize(): array
-    {
-        return $this->getAssets();
-    }
-
-    /**
-     * Prepares the bundle for caching.
-     *
-     * @param Asset[] $data
-     */
-    public function __unserialize(array $data): void
-    {
-        foreach ($data as $asset) {
-            $this->add($asset);
-        }
-    }
 }

--- a/tests/BundleTest.php
+++ b/tests/BundleTest.php
@@ -12,7 +12,7 @@ final class BundleTest extends AssetsTestCase
 {
     public function testConstructorPaths()
     {
-        $bundle              = new class() extends Bundle {
+        $bundle              = new class () extends Bundle {
             protected $paths = ['apple.css'];
         };
 
@@ -25,7 +25,7 @@ final class BundleTest extends AssetsTestCase
 
     public function testConstructorBundles()
     {
-        $bundle                = new class() extends Bundle {
+        $bundle                = new class () extends Bundle {
             protected $bundles = [FruitSalad::class];
         };
 
@@ -38,7 +38,7 @@ final class BundleTest extends AssetsTestCase
 
     public function testConstructorStrings()
     {
-        $bundle                = new class() extends Bundle {
+        $bundle                = new class () extends Bundle {
             protected $strings = ['foobar'];
         };
 
@@ -51,7 +51,7 @@ final class BundleTest extends AssetsTestCase
 
     public function testStringable()
     {
-        $asset               = new class() extends Bundle {
+        $asset               = new class () extends Bundle {
             protected $paths = ['apple.css'];
         };
 
@@ -60,7 +60,7 @@ final class BundleTest extends AssetsTestCase
 
     public function testHead()
     {
-        $asset               = new class() extends Bundle {
+        $asset               = new class () extends Bundle {
             protected $paths = [
                 'apple.css',
                 'banana.js',
@@ -68,5 +68,14 @@ final class BundleTest extends AssetsTestCase
         };
 
         $this->assertSame('<link href="http://example.com/assets/apple.css" rel="stylesheet" type="text/css" />', $asset->head());
+    }
+
+    public function testSerializing()
+    {
+        $bundle = new FruitSalad();
+
+        $result = unserialize(serialize($bundle));
+
+        $this->assertSame($bundle->body(), $result->body());
     }
 }

--- a/tests/RouteBundleTest.php
+++ b/tests/RouteBundleTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Tatter\Assets\Asset;
 use Tatter\Assets\Exceptions\AssetsException;
 use Tatter\Assets\RouteBundle;
 use Tests\Support\AssetsTestCase;
@@ -102,16 +101,5 @@ final class RouteBundleTest extends AssetsTestCase
         $this->expectExceptionMessage(lang('Assets.invalidConfigItem', ['']));
 
         RouteBundle::createFromRoute('invalid');
-    }
-
-    public function testSerializing()
-    {
-        $asset1 = new Asset('banana');
-        $asset2 = new Asset('bread', false);
-        $bundle = (new RouteBundle())->add($asset1)->add($asset2);
-
-        $result = unserialize(serialize($bundle));
-
-        $this->assertSame($bundle->body(), $result->body());
     }
 }


### PR DESCRIPTION
Moves `RouteBundle`'s cache support to the parent `Bundle`.