### PR TITLE
Fix backslash URI suffix on Windows

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -54,7 +54,7 @@ final class Asset
             self::$config = config(AssetsConfig::class);
 
             // Standardize formats
-            self::$config->uri       = rtrim(self::$config->uri, '/\\') . DIRECTORY_SEPARATOR;
+            self::$config->uri       = rtrim(self::$config->uri, '/\\') . '/';
             self::$config->directory = rtrim(self::$config->directory, '/\\') . DIRECTORY_SEPARATOR;
             self::$config->vendor    = rtrim(self::$config->vendor, '/\\') . DIRECTORY_SEPARATOR;
         }


### PR DESCRIPTION
Changed `$config->uri` to end with literal '/' instead of using DIRECTORY_SEPARATOR constant. Should resolve #48.