### PR TITLE
fix: assets config should not be called via class

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -51,7 +51,7 @@ final class Asset
     public static function config(): AssetsConfig
     {
         if (self::$config === null) {
-            self::$config = config(AssetsConfig::class);
+            self::$config = config('Assets');
 
             // Standardize formats
             self::$config->uri       = rtrim(self::$config->uri, '/\\') . '/';


### PR DESCRIPTION
@MGatner I had this problem for long time, I can't override Assets Config in different namespace than `App` for example in `Modules`, but it was not a big deal. Overwritten assets config was in App namespace and everything worked, but after update to CodeIgniter4 to v4.4.1 filters stop to working. This small change fixed an issue. Now it's working also with 4.4.1 as expected and I can move Assets config to my Assets module namespace. 